### PR TITLE
Added creation of _records table under target_scheme

### DIFF
--- a/sql_scripts/1b_gold_create.sql
+++ b/sql_scripts/1b_gold_create.sql
@@ -188,4 +188,9 @@ CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}._records (
 	total_records bigint DEFAULT 0
 )TABLESPACE pg_default;
 
-
+create table {TARGET_SCHEMA}._records (
+	tbl_name varchar(25) NOT NULL,
+	{TARGET_SCHEMA}_records bigint DEFAULT 0,
+	{TARGET_SCHEMA}_nok_records bigint DEFAULT 0,
+	total_records bigint DEFAULT 0
+)TABLESPACE pg_default;


### PR DESCRIPTION
It is found that the creation of _**_records**_ table under _**target_scheme**_ in _**GOLD**_ is missing. 