### PR TITLE
Added creating the SQL file creation code for UKBiobank _gp

### DIFF
--- a/sql_scripts/1a_ukb_gp_drop.sql
+++ b/sql_scripts/1a_ukb_gp_drop.sql
@@ -1,0 +1,3 @@
+drop table if exists {SOURCE_SCHEMA}.gp_registrations CASCADE;
+drop table if exists {SOURCE_SCHEMA}.gp_clinical CASCADE;
+drop table if exists {SOURCE_SCHEMA}.gp_scripts CASCADE;

--- a/sql_scripts/1b_ukb_gp_create.sql
+++ b/sql_scripts/1b_ukb_gp_create.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}.gp_registrations (
+	eid					bigint,	
+	data_provider		int,
+	reg_date			date,
+	deduct_date			date
+
+)TABLESPACE pg_default;
+
+CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}.gp_clinical (
+	eid					bigint,
+	data_provider		int,
+	event_dt			date,
+	read_2				varchar(50),
+	read_3				varchar(50),
+	value1				VARCHAR(20),
+	value2				VARCHAR(20),
+	value3				VARCHAR(20)
+)TABLESPACE pg_default;
+
+CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}.gp_scripts (
+	eid					bigint,	
+	data_provider		int,
+	issue_date			date,
+	read_2				varchar(50),
+	bnf_code			varchar(50),
+	dmd_code			varchar(20),
+	drug_name			varchar(500),
+	quantity			varchar(10)
+)TABLESPACE pg_default;

--- a/sql_scripts/1b_ukb_gp_create.sql
+++ b/sql_scripts/1b_ukb_gp_create.sql
@@ -10,8 +10,8 @@ CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}.gp_clinical (
 	eid					bigint,
 	data_provider		int,
 	event_dt			date,
-	read_2				varchar(50),
-	read_3				varchar(50),
+	read_2				varchar(7),
+	read_3				varchar(7),
 	value1				VARCHAR(20),
 	value2				VARCHAR(20),
 	value3				VARCHAR(20)
@@ -21,9 +21,9 @@ CREATE TABLE IF NOT EXISTS {SOURCE_SCHEMA}.gp_scripts (
 	eid					bigint,	
 	data_provider		int,
 	issue_date			date,
-	read_2				varchar(50),
-	bnf_code			varchar(50),
+	read_2				varchar(7),
+	bnf_code			varchar(14),
 	dmd_code			varchar(20),
 	drug_name			varchar(500),
-	quantity			varchar(10)
+	quantity			varchar(20)
 )TABLESPACE pg_default;


### PR DESCRIPTION
Since the document primary_care_data.pdf (p.16) and [the UKBiobank](https://biobank.ndph.ox.ac.uk/ukb/label.cgi?id=3001) browser do not provide information about the length of string values, and I am currently not able to access the source data, I defined them based on common sense. Amendments may be required in the future.  

![image](https://github.com/oxford-pharmacoepi/etl_ndorms/assets/114593559/337afb7e-6da5-433b-b4fc-2852d4429858)
