### PR TITLE
 Adding creation scripts of PK and idx for BioBank_HES tables

### DIFF
--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin.sql
@@ -1,0 +1,3 @@
+--biob_hesin
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin ADD CONSTRAINT pk_biob_hesin PRIMARY KEY (eid,ins_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_eid on {SOURCE_SCHEMA}.biob_hesin (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_critical.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_critical.sql
@@ -1,0 +1,3 @@
+--biob_hesin_critical
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_critical ADD CONSTRAINT pk_biob_hesin_critical PRIMARY KEY (eid,ins_index,arr_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_critical_eid on {SOURCE_SCHEMA}.biob_hesin_critical (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_delivery.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_delivery.sql
@@ -1,0 +1,3 @@
+--biob_hesin_delivery
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_delivery ADD CONSTRAINT pk_biob_hesin_delivery PRIMARY KEY (eid,ins_index,arr_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_delivery_eid on {SOURCE_SCHEMA}.biob_hesin_delivery (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_diag.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_diag.sql
@@ -1,0 +1,3 @@
+--biob_hesin_diag
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_diag ADD CONSTRAINT pk_biob_hesin_diag PRIMARY KEY (eid,ins_index,arr_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_diag on {SOURCE_SCHEMA}.biob_hesin_diag (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_maternity.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_maternity.sql
@@ -1,0 +1,3 @@
+--biob_hesin_maternity
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_maternity ADD CONSTRAINT pk_biob_hesin_maternity PRIMARY KEY (eid,ins_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_maternity_eid on {SOURCE_SCHEMA}.biob_hesin_maternity (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_oper.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_oper.sql
@@ -1,0 +1,3 @@
+--biob_hesin_oper
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_oper ADD CONSTRAINT pk_biob_hesin_oper PRIMARY KEY (eid,ins_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_oper_eid on {SOURCE_SCHEMA}.biob_hesin_oper (eid) TABLESPACE pg_default;

--- a/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_psych.sql
+++ b/sql_scripts/1c_ukb_hesin_pk_idx_biob_hesin_psych.sql
@@ -1,0 +1,3 @@
+--biob_hesin_psych
+ALTER TABLE {SOURCE_SCHEMA}.biob_hesin_psych ADD CONSTRAINT pk_biob_hesin_psych PRIMARY KEY (eid,ins_index) USING INDEX TABLESPACE pg_default;
+create index idx_biob_hesin_psych_eid on {SOURCE_SCHEMA}.biob_hesin_psych (eid) TABLESPACE pg_default;


### PR DESCRIPTION
@adelmestri,

The following files have been created for the creation of BioBank_HES table PK's & Index's:

      1. 1c_ukb_hesin_pk_idx_biob_hesin.sql
      2. 1c_ukb_hesin_pk_idx_biob_hesin_critical.sql
      3. 1c_ukb_hesin_pk_idx_biob_hesin_delivery.sql
      4. 1c_ukb_hesin_pk_idx_biob_hesin_diag.sql
      5. 1c_ukb_hesin_pk_idx_biob_hesin_maternity.sql
      6. 1c_ukb_hesin_pk_idx_biob_hesin_oper.sql
      7. 1c_ukb_hesin_pk_idx_biob_hesin_psych.sql

please review and approve at your earliest convinence.
 